### PR TITLE
feat: token chunking for large disassembly input

### DIFF
--- a/pychd/decompile.py
+++ b/pychd/decompile.py
@@ -83,7 +83,10 @@ def _get_max_input_tokens(model: str, default: int = 8192) -> int:
     """Return the maximum input tokens for a model, falling back to *default*."""
     try:
         info = litellm.get_model_info(model)
-        return info["max_input_tokens"]
+        max_tokens = info["max_input_tokens"]
+        if max_tokens is not None:
+            return max_tokens
+        return default
     except Exception:
         logging.debug(
             f"Could not retrieve model info for {model!r}; using default {default}"

--- a/pychd/decompile.py
+++ b/pychd/decompile.py
@@ -6,7 +6,8 @@ import sys
 import textwrap
 from pathlib import Path
 
-from litellm import completion
+import litellm
+from litellm import completion, token_counter
 from xdis.disasm import disco
 from xdis.load import load_module
 
@@ -78,11 +79,60 @@ def disassemble_pyc_file(pyc_file: Path) -> tuple[str, tuple]:
     return disassembled_pyc, version_tuple
 
 
-def decompile_disassembled_pyc(
-    disassembled_pyc: str, version_tuple: tuple, model: ModelType
+def _get_max_input_tokens(model: str, default: int = 8192) -> int:
+    """Return the maximum input tokens for a model, falling back to *default*."""
+    try:
+        info = litellm.get_model_info(model)
+        return info["max_input_tokens"]
+    except Exception:
+        logging.debug(
+            f"Could not retrieve model info for {model!r}; using default {default}"
+        )
+        return default
+
+
+def _split_disassembly(text: str, max_tokens: int, model: str) -> list[str]:
+    """Split disassembly text into chunks that each fit within *max_tokens*.
+
+    The text is first split on blank-line boundaries (``\\n\\n``). Consecutive
+    blocks are greedily grouped so that the token count of each chunk stays
+    within the limit.  If a single block exceeds the limit it is emitted as
+    its own chunk.
+    """
+    blocks = text.split("\n\n")
+    chunks: list[str] = []
+    current_blocks: list[str] = []
+    current_text = ""
+
+    for block in blocks:
+        candidate = current_text + "\n\n" + block if current_text else block
+        candidate_tokens = token_counter(model=model, text=candidate)
+        if candidate_tokens <= max_tokens or not current_blocks:
+            # Still fits, or this is the very first block (must include it).
+            current_blocks.append(block)
+            current_text = candidate
+        else:
+            # Adding this block would exceed the limit – flush current chunk.
+            chunks.append(current_text)
+            current_blocks = [block]
+            current_text = block
+
+    # Don't forget the last chunk.
+    if current_text:
+        chunks.append(current_text)
+
+    return chunks
+
+
+def _decompile_chunk(
+    disassembled_pyc: str,
+    version_tuple: tuple,
+    model: ModelType,
+    part_info: str | None = None,
 ) -> str:
-    logging.info(f"{model=}")
+    """Send a single (possibly chunked) disassembly to the LLM and return source."""
     version_str = f"{version_tuple[0]}.{version_tuple[1]}"
+    part_line = f"\nThis is {part_info} of the disassembly.\n" if part_info else ""
     user_prompt = textwrap.dedent(
         f"""\
         You are a Python decompiler.
@@ -91,7 +141,7 @@ def decompile_disassembled_pyc(
         Output only the original full source code.
         Do not the natural language description.
         Do not surround the code with triple quotes such as '```' or '```python'.
-        ```
+        {part_line}```
         {disassembled_pyc}
         ```
         """
@@ -105,6 +155,30 @@ def decompile_disassembled_pyc(
     generated_text: str = response.choices[0].message.content
     logging.debug(f"{generated_text=}")
     return generated_text
+
+
+def decompile_disassembled_pyc(
+    disassembled_pyc: str, version_tuple: tuple, model: ModelType
+) -> str:
+    logging.info(f"{model=}")
+
+    # Reserve tokens for the prompt template and model output.
+    prompt_overhead = 2000
+    max_input = _get_max_input_tokens(model) - prompt_overhead
+
+    chunks = _split_disassembly(disassembled_pyc, max_tokens=max_input, model=model)
+
+    if len(chunks) == 1:
+        return _decompile_chunk(disassembled_pyc, version_tuple, model)
+
+    logging.info(f"Disassembly split into {len(chunks)} chunks")
+    parts: list[str] = []
+    for idx, chunk in enumerate(chunks, 1):
+        part_info = f"Part {idx} of {len(chunks)}"
+        logging.info(f"Decompiling {part_info}...")
+        parts.append(_decompile_chunk(chunk, version_tuple, model, part_info=part_info))
+
+    return "\n\n".join(parts)
 
 
 def decompile(

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+
+from pychd.decompile import (
+    _get_max_input_tokens,
+    _split_disassembly,
+    decompile_disassembled_pyc,
+)
+
+
+class TestGetMaxInputTokens:
+    def test_returns_model_info(self):
+        with patch("pychd.decompile.litellm") as mock_litellm:
+            mock_litellm.get_model_info.return_value = {"max_input_tokens": 16000}
+            assert _get_max_input_tokens("gpt-4") == 16000
+
+    def test_fallback_on_error(self):
+        with patch("pychd.decompile.litellm") as mock_litellm:
+            mock_litellm.get_model_info.side_effect = Exception("unknown model")
+            assert _get_max_input_tokens("unknown-model", default=4096) == 4096
+
+
+class TestSplitDisassembly:
+    def test_single_chunk_when_small(self):
+        with patch("pychd.decompile.token_counter", return_value=100):
+            chunks = _split_disassembly("small text", max_tokens=1000, model="gpt-4")
+            assert len(chunks) == 1
+            assert chunks[0] == "small text"
+
+    def test_multiple_chunks_when_large(self):
+        blocks = ["block1", "block2", "block3", "block4"]
+        text = "\n\n".join(blocks)
+
+        def fake_token_counter(model, text):
+            # Each individual block is ~100 tokens, combined they exceed limit
+            if "\n\n" in text:
+                return len(text.split("\n\n")) * 100
+            return 100
+
+        with patch("pychd.decompile.token_counter", side_effect=fake_token_counter):
+            chunks = _split_disassembly(text, max_tokens=250, model="gpt-4")
+            assert len(chunks) > 1
+
+
+class TestDecompileWithChunking:
+    def test_single_chunk_no_part_info(self):
+        with (
+            patch("pychd.decompile._get_max_input_tokens", return_value=100000),
+            patch("pychd.decompile.token_counter", return_value=100),
+            patch("pychd.decompile.completion") as mock_completion,
+        ):
+            mock_response = MagicMock()
+            mock_response.choices[0].message.content = "print('hello')"
+            mock_completion.return_value = mock_response
+            result = decompile_disassembled_pyc("LOAD_CONST 0", (3, 14), "gpt-4")
+            assert result == "print('hello')"
+            # Check that "Part" is NOT in the prompt
+            call_args = mock_completion.call_args
+            prompt = (
+                call_args[1]["messages"][0]["content"]
+                if "messages" in call_args[1]
+                else call_args[0][0]
+            )
+            assert "Part" not in prompt
+
+    def test_multi_chunk_concatenation(self):
+        blocks = "\n\n".join([f"BLOCK_{i}" for i in range(10)])
+        call_count = [0]
+
+        def fake_token_counter(model, text):
+            return len(text) * 2  # make tokens proportional to length
+
+        def fake_completion(**kwargs):
+            call_count[0] += 1
+            mock_response = MagicMock()
+            mock_response.choices[0].message.content = f"# chunk {call_count[0]}"
+            return mock_response
+
+        with (
+            patch("pychd.decompile._get_max_input_tokens", return_value=200),
+            patch("pychd.decompile.token_counter", side_effect=fake_token_counter),
+            patch("pychd.decompile.completion", side_effect=fake_completion),
+        ):
+            result = decompile_disassembled_pyc(blocks, (3, 14), "gpt-4")
+            assert call_count[0] > 1
+            assert "# chunk 1" in result


### PR DESCRIPTION
## Summary
- Add automatic chunking when disassembled bytecode exceeds the model's token limit
- Use `litellm.get_model_info()` to detect max input tokens, with configurable fallback
- Split disassembly by `\n\n` blocks and greedily group into chunks using `litellm.token_counter()`
- Each chunk is sent as "Part N of M" to the LLM and results are joined

## Test plan
- [x] Unit tests for `_get_max_input_tokens` (model info lookup + fallback)
- [x] Unit tests for `_split_disassembly` (single chunk + multi-chunk)
- [x] Integration tests for `decompile_disassembled_pyc` with mocked LLM (single + multi-chunk)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)