### PR TITLE
feat: add pytest infrastructure and example-based tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,6 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["pychd"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "example" / "python"
+
+
+def _example_files():
+    return sorted(EXAMPLE_DIR.glob("*.py"))
+
+
+@pytest.fixture(params=_example_files(), ids=lambda p: p.name)
+def example_py(request):
+    """Yield each example .py file as a Path."""
+    return request.param

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,28 @@
+import tempfile
+from pathlib import Path
+
+from pychd.compile import compile
+
+
+class TestCompileSingleFile:
+    def test_compile_creates_pyc(self, example_py):
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp) / "output.pyc"
+            compile(to_compile=example_py, output_path=output)
+            assert output.exists()
+            assert output.stat().st_size > 0
+
+
+class TestCompileDirectory:
+    def test_compile_dir(self, tmp_path):
+        # Create a small .py file in a temp directory
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "hello.py").write_text("x = 1\n")
+        out = tmp_path / "out"
+        compile(to_compile=src, output_path=out)
+        # compileall creates __pycache__ inside the source dir
+        pycache = src / "__pycache__"
+        assert pycache.exists()
+        pyc_files = list(pycache.glob("*.pyc"))
+        assert len(pyc_files) >= 1

--- a/tests/test_decompile.py
+++ b/tests/test_decompile.py
@@ -1,0 +1,40 @@
+import py_compile
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pychd.decompile import decompile, decompile_disassembled_pyc, disassemble_pyc_file
+
+
+class TestDisassemble:
+    def test_disassemble_produces_output(self, example_py):
+        """Compile an example .py then disassemble the .pyc."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pyc = Path(tmp) / "output.pyc"
+            py_compile.compile(str(example_py), cfile=str(pyc))
+            text, version_tuple = disassemble_pyc_file(pyc)
+            assert len(text) > 0
+            assert isinstance(version_tuple, tuple)
+            assert len(version_tuple) >= 2
+
+
+class TestDecompileWithMockedLLM:
+    def test_decompile_returns_mocked_source(self):
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "x = 42"
+        with patch("pychd.decompile.completion", return_value=mock_response):
+            result = decompile_disassembled_pyc("LOAD_CONST 0", (3, 14), "gpt-4")
+            assert result == "x = 42"
+
+    def test_decompile_end_to_end_mocked(self, example_py):
+        """Full pipeline: compile -> disassemble -> decompile (mocked LLM)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            pyc = Path(tmp) / "output.pyc"
+            py_compile.compile(str(example_py), cfile=str(pyc))
+            out = Path(tmp) / "result.py"
+            mock_response = MagicMock()
+            mock_response.choices[0].message.content = "# decompiled"
+            with patch("pychd.decompile.completion", return_value=mock_response):
+                decompile(to_decompile=pyc, output_path=out, model="gpt-4")
+            assert out.exists()
+            assert out.read_text() == "# decompiled"


### PR DESCRIPTION
## Summary
- Configure pytest in `pyproject.toml` with `testpaths = ["tests"]`
- Add `conftest.py` with parameterized fixtures for `example/python/*.py` files
- Add `test_compile.py` for single-file and directory compilation verification
- Add `test_decompile.py` for disassembly pipeline and mocked LLM end-to-end tests

## Test plan
- [x] 11 parameterized compile tests (one per example file)
- [x] Directory compilation test
- [x] 11 parameterized disassembly tests
- [x] Mocked LLM unit test
- [x] 11 parameterized end-to-end tests (compile → disassemble → mocked decompile)
- Total: 35 tests passing

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)