### PR TITLE
feat: v1.0.0 — automated PyPI publishing via trusted publisher

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,29 +1,28 @@
-name: Publish PyPI
+name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
   push:
     tags:
-      - '*'
+      - "v*"
 
 jobs:
-  publish:
-    name: publish
+  ci:
+    name: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v2
+      - run: just ci
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: 0.34.0
-          RYE_INSTALL_OPTION: "--yes"
-
-      - name: Publish to PyPI
-        run: |
-          bash ./bin/publish-pypi
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+  publish:
+    name: publish
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/bin/publish-pypi
+++ b/bin/publish-pypi
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -eux
-rm -rf dist
-uv build
-uv publish --token "$PYPI_TOKEN"

--- a/justfile
+++ b/justfile
@@ -40,6 +40,7 @@ decompile path model="ollama/deepseek-r1": build
 validate original decompiled: build
     docker run --rm -v "$(pwd)":/app {{ image }} uv run pychd validate {{ original }} {{ decompiled }}
 
-# Build and publish to PyPI (requires PYPI_TOKEN env var)
-publish: build
-    docker run --rm -e PYPI_TOKEN {{ image }} sh -c 'uv build && uv publish --token "$PYPI_TOKEN"'
+# Tag a release and push (triggers publish workflow)
+release version:
+    git tag -a "v{{ version }}" -m "v{{ version }}"
+    git push origin "v{{ version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pychd"
-version = "0.2.4"
-description = "The ChatGPT-powered decompiler for Python, providing superior code analysis capabilities"
+version = "1.0.0"
+description = "LLM-powered Python bytecode decompiler supporting multiple providers via litellm"
 readme = "README.md"
 authors = [
     { name = "卍diohabara卍", email = "diohabara@users.noreply.github.com" }


### PR DESCRIPTION
## Summary
- Bump version to **1.0.0**
- Rewrite `publish.yaml`: tag push `v*` triggers lint+test then publishes to PyPI via OIDC trusted publisher
- Add `just release <version>` recipe (creates annotated tag and pushes)
- Remove `bin/publish-pypi` (replaced by CI)

## How to release
```bash
# After this PR is merged:
just release 1.0.0
```
This creates tag `v1.0.0` and pushes it, which triggers the publish workflow.

## PyPI Trusted Publisher setup required
Before the first publish, configure the trusted publisher on PyPI:

1. Go to https://pypi.org/manage/project/pychd/settings/publishing/
2. Add a new publisher:
   - **Owner**: `diohabara`
   - **Repository**: `pychd`
   - **Workflow name**: `publish.yaml`
   - **Environment**: `pypi`

## Test plan
- [x] `just ci` passes locally (50 tests, all linters green)
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)